### PR TITLE
runNpm: check the platform before running child_process.spawn()

### DIFF
--- a/mainrp.js
+++ b/mainrp.js
@@ -74,7 +74,9 @@ function runNpm(command) {
 	console.log('Running `npm ' + command + '`...');
 
 	var child_process = require('child_process');
-	var npm = child_process.spawn('npm', [command]);
+	// Windows will actually error on "npm", so check the platform before continuing.
+	var baseCommand = (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+	var npm = child_process.spawn(baseCommand, [command]);
 
 	npm.stdout.on('data', function(data) {
 		process.stdout.write(data);


### PR DESCRIPTION
Windows requires `npm.cmd` instead of `npm` for the function to properly work, else it will return an error.